### PR TITLE
gf

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       POSTGRES_USER: ${DB_POSTGRESDB_USER:-${PG_USER}}
       POSTGRES_DB: ${PG_DB:-cosmocrat}
     volumes:
-      - PGDATA:/var/lib/postgresql/data
+      - pg_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_POSTGRESDB_USER:-${PG_USER}} -d ${PG_DB:-cosmocrat}"]
       interval: 5s


### PR DESCRIPTION
fg

## Summary by Sourcery

Update docker-compose volumes by standardizing the Postgres data volume name and cleaning up an obsolete clickhouse_data entry

Enhancements:
- Rename Postgres data volume in docker-compose from PGDATA to pg_data
- Remove unused clickhouse_data volume definition