### PR TITLE
Remove minio dependency from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,6 @@ services:
     depends_on: &langfuse-depends-on
       postgres:
         condition: service_healthy
-      minio:
-        condition: service_healthy
       redis:
         condition: service_healthy
       clickhouse:


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Eliminate the minio service from the depends_on list in docker-compose.yml