### PR TITLE
Handle outdated docker client version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,15 @@ x-doppler: &doppler-env
     - {{$key}}={{$value}}{{end}}
 services:
   traefik:
-    image: traefik:v2.11
+    image: traefik:v3.1
     command:
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
       - --entrypoints.web.address=:8888
+    environment:
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - DOCKER_API_VERSION=1.44
+      - TRAEFIK_PROVIDERS_DOCKER_APIVERSION=1.44
     ports:
       - "8888:8888"
     volumes:


### PR DESCRIPTION
Update Traefik configuration to resolve Docker API version mismatch.

---
<a href="https://cursor.com/background-agent?bcId=bc-33161734-7191-4b9e-85d1-978601ce0ac5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33161734-7191-4b9e-85d1-978601ce0ac5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Update Traefik service configuration in docker-compose to use the latest v3.1 image and explicitly set the Docker API version to resolve client version mismatches.

Enhancements:
- Upgrade Traefik image from v2.11 to v3.1
- Add environment variables to pin Docker host and API version to 1.44 for Traefik