### PR TITLE
Handle outdated docker client version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,16 @@ x-doppler: &doppler-env
     - {{$key}}={{$value}}{{end}}
 services:
   traefik:
-    image: traefik:v2.11
+    image: traefik:v3.1
     command:
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
+      - --providers.docker.apiversion=1.51
       - --entrypoints.web.address=:8888
+    environment:
+      DOCKER_HOST: unix:///var/run/docker.sock
+      DOCKER_API_VERSION: "1.51"
+      TRAEFIK_PROVIDERS_DOCKER_APIVERSION: "1.51"
     ports:
       - "8888:8888"
     volumes:


### PR DESCRIPTION
Upgrade Traefik to v3.1 and explicitly set Docker API version to 1.51 to resolve 'client version too old' errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-15103e95-77de-48ca-9d64-1bfb1ab849b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-15103e95-77de-48ca-9d64-1bfb1ab849b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Upgrade Traefik to v3.1 and explicitly pin the Docker API version to 1.51 to fix client compatibility issues

Bug Fixes:
- Resolve Docker client version mismatch errors by pinning the API version to 1.51

Enhancements:
- Upgrade Traefik image to v3.1
- Pin Docker API version to 1.51 via a command flag and environment variables
- Configure DOCKER_HOST for Traefik to use the local Docker socket